### PR TITLE
requirements.txt Fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyautogui
-tkinter
 customtkinter==5.2
 pillow
 pyttsx3
+keyboard


### PR DESCRIPTION
Removed tkinter from file because it doesn't exist as a pip package, added keyboard module to be installed, because it is required by GUIHelpers.py